### PR TITLE
Update Minimatch to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "lib",
   "dependencies": {
-    "minimatch": "3.0.0"
+    "minimatch": "3.0.3"
   },
   "devDependencies": {
     "chai": "3.x",


### PR DESCRIPTION
Fixes `npm WARN deprecated minimatch@3.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`
